### PR TITLE
Fix compile failure due to missing size_t definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ git clone https://github.com/nasa-gibs/mrf.git
 
 Copy the MRF GDAL driver to the GDAL source tree (the plugin must be compiled here):
 ```
-cp -R mrf/src/gdal-mrf/frmts/mrf <gdal source directory>/frmts/
+cp -R mrf/src/gdal_mrf/frmts/mrf <gdal source directory>/frmts/
 ```
 
 Go to the mrf driver source directory:

--- a/src/gdal_mrf/frmts/mrf/Defines.h
+++ b/src/gdal_mrf/frmts/mrf/Defines.h
@@ -20,6 +20,7 @@ Contributors:
 #pragma once
 // For std::pair
 #include <utility>
+#include <cstddef>
 typedef unsigned char Byte;
 
 // unsigned long pair sortable by first


### PR DESCRIPTION
When compiling as a gdal plugin (after having copied the src tree into `frmts`), this change is necessary to avoid a compiler error.

`BitMask.cpp:44:5: error: 'size_t' was not declared in this scope`