### PR TITLE
Jpng

### DIFF
--- a/src/gdal_mrf/frmts/mrf/marfa.h
+++ b/src/gdal_mrf/frmts/mrf/marfa.h
@@ -602,7 +602,7 @@ public:
     CPLErr CompressPNG(buf_mgr &dst, buf_mgr &src);
     CPLErr DecompressPNG(buf_mgr &dst, buf_mgr &src);
 
-    const ILImage &img;
+    const ILImage img;
 
     void *PNGColors;
     void *PNGAlpha;
@@ -642,7 +642,7 @@ public:
     CPLErr DecompressJPEG12(buf_mgr &dst, buf_mgr &src);
 #endif
 
-    const ILImage &img;
+    const ILImage img;
 
     // JPEG specific flags
     bool sameres;


### PR DESCRIPTION
Tried to hard to save memory by keeping only references to the image object.  The JPG, PNG and the new JPNG have been broken for a while, including in the 2.1 GDAL release