### PR TITLE
Canned index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ update*
 *.obj
 /dist/
 /docker/el7/rpms/
+
+# Visual Studio
+.vs
+Debug
+Release
+*.user

--- a/mrf_apps/can.cpp
+++ b/mrf_apps/can.cpp
@@ -380,7 +380,7 @@ int uncan(const options &opt) {
     uint64_t out_size = 16 * be64toh(*reinterpret_cast<uint64_t *>(&header[2]));
 
     // Verify that the sizes make sense
-    if (header_size != canned_size(out_size))
+    if (header_size * 4 != canned_size(out_size))
         return Usage("Input header is corrupt");
 
     if (!opt.quiet)

--- a/mrf_apps/can.cpp
+++ b/mrf_apps/can.cpp
@@ -68,9 +68,11 @@
 
 using namespace std;
 
+// Error codes
+enum { NO_ERR = 0, USAGE_ERR, IO_ERR, INTERNAL_ERR };
+
 // Block size used, do not modify
 const int BSZ = 512;
-
 // 4 byte length signature string
 const char *SIG = "IDX";
 
@@ -159,8 +161,6 @@ static options parse(int argc, char **argv) {
 
     return opt;
 }
-
-enum ERRORS { NO_ERR = 0, USAGE_ERR, IO_ERR, INTERNAL_ERR };
 
 static int Usage(const string &error) {
     cerr << error << endl;

--- a/mrf_apps/can.cpp
+++ b/mrf_apps/can.cpp
@@ -469,7 +469,8 @@ int uncan(const options &opt) {
     // Need to end the file at the current position, to get the right size
     MARK_END(out_idx);
     fclose(out_idx);
-    return INTERNAL_ERR;
+
+    return NO_ERR;
 }
 
 int main(int argc, char **argv)

--- a/mrf_apps/mrf_apps.sln
+++ b/mrf_apps/mrf_apps.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2019
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mrf_apps", "mrf_apps.vcxproj", "{E392B36A-171A-4CCF-A974-29B20AD6D302}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E392B36A-171A-4CCF-A974-29B20AD6D302}.Debug|x64.ActiveCfg = Debug|x64
+		{E392B36A-171A-4CCF-A974-29B20AD6D302}.Debug|x64.Build.0 = Debug|x64
+		{E392B36A-171A-4CCF-A974-29B20AD6D302}.Debug|x86.ActiveCfg = Debug|Win32
+		{E392B36A-171A-4CCF-A974-29B20AD6D302}.Debug|x86.Build.0 = Debug|Win32
+		{E392B36A-171A-4CCF-A974-29B20AD6D302}.Release|x64.ActiveCfg = Release|x64
+		{E392B36A-171A-4CCF-A974-29B20AD6D302}.Release|x64.Build.0 = Release|x64
+		{E392B36A-171A-4CCF-A974-29B20AD6D302}.Release|x86.ActiveCfg = Release|Win32
+		{E392B36A-171A-4CCF-A974-29B20AD6D302}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7E5750A3-4867-4B5E-84E7-887B1506BA43}
+	EndGlobalSection
+EndGlobal

--- a/mrf_apps/mrf_apps.vcxproj
+++ b/mrf_apps/mrf_apps.vcxproj
@@ -19,7 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="packindex.cpp" />
+    <ClCompile Include="can.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>

--- a/mrf_apps/mrf_apps.vcxproj
+++ b/mrf_apps/mrf_apps.vcxproj
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{E392B36A-171A-4CCF-A974-29B20AD6D302}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>mrfapps</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/mrf_apps/mrf_apps.vcxproj
+++ b/mrf_apps/mrf_apps.vcxproj
@@ -27,6 +27,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>mrfapps</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <ProjectName>packindex</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -106,7 +107,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>

--- a/mrf_apps/mrf_apps.vcxproj
+++ b/mrf_apps/mrf_apps.vcxproj
@@ -18,6 +18,9 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="packindex.cpp" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{E392B36A-171A-4CCF-A974-29B20AD6D302}</ProjectGuid>
@@ -30,7 +33,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -43,7 +46,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -99,7 +102,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>

--- a/mrf_apps/mrf_apps.vcxproj.filters
+++ b/mrf_apps/mrf_apps.vcxproj.filters
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/mrf_apps/mrf_apps.vcxproj.filters
+++ b/mrf_apps/mrf_apps.vcxproj.filters
@@ -14,4 +14,9 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="packindex.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
 </Project>

--- a/mrf_apps/mrf_apps.vcxproj.filters
+++ b/mrf_apps/mrf_apps.vcxproj.filters
@@ -15,7 +15,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="packindex.cpp">
+    <ClCompile Include="can.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/mrf_apps/packindex.cpp
+++ b/mrf_apps/packindex.cpp
@@ -5,9 +5,16 @@
  *
  * Packed Format:
  *
- * The MRF packed format consist of a header of size 32 * (1 + isize / 49152), followed
+ * The MRF packed format consist of a header of size 16 * ((49151 + isize) / 49152), followed
  * by the 512 byte blocks of the original MRF index that do hold value
- * The output index will be 1/1536 of the original size, plus the actual content blocks
+ * The output index will be a few bytes over 1:3072 (0.03255%) of the original virtual size, 
+ * plus the actual content blocks.
+ *
+ * This is because the header is formed of 96 bit masks for every 96 blocks of 512 bytes each, 
+ * plus a 32 bit running count of previously existing blocks. Thus, every 96 input blocks will 
+ * use 16 bytes.  Since the size of the header can be calculated based on the MRF size
+ * it is used as a check that the header is correct.  Also the total number of set bits in the 
+ * header has to be equal to the number of blocks in the file, which results in another check
  * 
  */
 
@@ -20,6 +27,9 @@
 
 using namespace std;
 
+// Block size used, do not modify
+const int BSZ = 512;
+
 // Compare a substring of src with cmp, return true if same
 // offset can be negative, in which case it is measured from the end of the src, python style
 static bool substr_equal(const string &src, const string &cmp, int off = 0, size_t len = 0) {
@@ -30,8 +40,9 @@ static bool substr_equal(const string &src, const string &cmp, int off = 0, size
     return cmp == (len ? src.substr(off, len) : src.substr(off));
 }
 
-inline bool check(const char *src, size_t len = 512) {
-    assert(len % 8 == 0);
+// Returns true if the block is filled with zeros
+inline bool check(const char *src, size_t len = BSZ) {
+    assert(len % 8 == 0); // So we can use uint64_t
     len /= 8;
     const uint64_t *p = reinterpret_cast<const uint64_t *>(src);
     uint64_t accumulator = 0;
@@ -40,68 +51,176 @@ inline bool check(const char *src, size_t len = 512) {
     return 0 == accumulator;
 }
 
+// Program options
+struct options {
+    string in_idx_name;
+    string out_idx_name;
+    string error; // Empty if parsing went fine
+    bool unpack; // Pack by default
+    bool quiet;  // Verbose by default
+};
 
-int main(int argc, char **argv)
-{
-    assert(argc > 2);
-    string in_idx_name(argv[1]);
-    string out_idx_name(argv[2]);
-    assert(substr_equal(in_idx_name, ".idx", -4));
-    assert(substr_equal(out_idx_name, ".ix", -3));
+static options parse(int argc, char **argv) {
+    options opt;
+    for (int i = 1; i < argc; i++) {
+        string arg(argv[i]);
+        if (0 == arg.find_first_of("-")) {
+            if (arg == "-q") {
+                opt.quiet = true;
+                continue;
+            }
+            else
+            if (arg == "-u") {
+                opt.unpack = true;
+                continue;
+            }
+            else {
+                opt.error = string("Unknown option ") + arg;
+                return opt;
+            }
+        }
+        else { // file names
+            if (opt.in_idx_name.empty()) {
+                opt.in_idx_name = argv[i];
+                if (!substr_equal(opt.in_idx_name, ".idx", -4)) {
+                    opt.error = "Input file name should end in .idx";
+                    return opt;
+                }
+            }
+            else {
+                if (!opt.out_idx_name.empty()) {
+                    opt.error = "Too many files names";
+                    return opt;
+                }
+                opt.out_idx_name = argv[i];
+                if (!substr_equal(opt.out_idx_name, ".ix", -3)) {
+                    opt.error = "Input file name should end in .ix";
+                    return opt;
+                }
+            }
+        }
+    }
+
+    // Final checks
+    if (opt.in_idx_name.empty() || opt.out_idx_name.empty())
+        opt.error = "Need input and output file names";
+
+    return opt;
+}
+
+enum ERRORS { NO_ERR = 0, USAGE_ERR, IO_ERR, INTERNAL_ERR };
+
+int Usage(const string &error) {
+    cerr << error << endl;
+    return USAGE_ERR;
+}
+
+int pack(const options &opt) {
+    string in_idx_name(opt.in_idx_name);
+    string out_idx_name(opt.out_idx_name);
 
     ifstream in_idx(in_idx_name, fstream::binary);
     ofstream out_idx(out_idx_name, fstream::binary);
 
     if (!in_idx.is_open() || !out_idx.is_open()) {
-        cerr << "Can't open " << (in_idx.is_open() ? out_idx_name: in_idx_name) << endl;
-        return 1;
+        cerr << "Can't open " << (in_idx.is_open() ? out_idx_name : in_idx_name) << endl;
+        return IO_ERR;
     }
 
     in_idx.seekg(0, fstream::end);
     auto in_size = in_idx.tellg();
     in_idx.seekg(0);
-    assert(in_size % 16 == 0);
 
-    uint64_t header_size = 32 * (1 + in_size / 49152);
-    cout << "Header will be " << header_size << " bytes" << endl;
+    // Input has to be an index, which is always a multiple of 16 bytes
+    if (in_size % 16) {
+        cerr << "Input file is not an index file, size is not a multiple of 16\n";
+        return USAGE_ERR;
+    }
+
+    // Output has a 16 bit reserved line plus the line array
+    uint64_t header_size = 16 * ((96 * BSZ - 1 + in_size) / (96 * BSZ));
+    if (!opt.quiet)
+        cout << "Header will be " << header_size << " bytes" << endl;
 
     // Get space for the header and reserve space on disk,
     // Header will be written at the end
-    vector<uint64_t> header(header_size / sizeof(uint64_t));
+    vector<uint32_t> header(header_size / sizeof(uint32_t));
+
+    // Reserve space for the header
     out_idx.seekp(header_size, fstream::beg);
-    
-    size_t out_block_count = 0;
-    size_t in_block_count = 1 + in_size / 512;
+
+    // Running count of output blocks
+    size_t count = 0;
+    size_t in_block_count = (BSZ - 1 + in_size) / BSZ;
     // Block buffer
-    char buffer[512];
+    char buffer[BSZ];
+
+    // Current line start within header as a 32bit int index
+    // always a multiple of 4, since there are 4 ints per line
+    int line = 0;
+    // and current bit position within that line
+    int bit_pos = 0;
 
     // Check all full blocks, transferring them as needed
     while (--in_block_count) {
-        in_idx.read(buffer, 512);
+        in_idx.read(buffer, BSZ);
+
         if (!check(buffer)) {
-            out_idx.write(buffer, 512);
-            out_block_count++;
+            out_idx.write(buffer, BSZ);
+            // Flip the bit that represents this value
+            header[line + 1 + bit_pos / 32] |= 1 << (bit_pos % 32);
+            count++;
+        }
+
+        bit_pos++;
+        if (bit_pos % 96 == 0) {
+            // Start a new line, store the running count
+            bit_pos = 0;
+            line += 4;
+            // If there is another line, initialize running count
+            if (line < header.size())
+                header[line] = static_cast<uint32_t>(count);
         }
     }
 
-    // Last block can be partial
-    if (in_size % 512) {
-        auto extras = in_size % 512 / 8;
-        in_idx.read(reinterpret_cast<char *>(buffer), extras * 8);
-        for (auto i = extras ; i < 512 / 8 ; i++)
+    // The very last block may be partial
+    if (in_size % BSZ) {
+        auto extra_bytes = in_size % BSZ;
+        in_idx.read(reinterpret_cast<char *>(buffer), extra_bytes);
+        // The buffer is in int64_t, so we divide by 8
+        for (auto i = extra_bytes; i < BSZ; i++)
             buffer[i] = 0;
+
         if (!check(buffer)) {
-            out_idx.write(buffer, 512);
-            out_block_count++;
+            out_idx.write(buffer, BSZ);
+            // Flip the bit in the header
+            header[line + 1 + bit_pos / 32] |= 1 << (bit_pos % 32);
         }
     }
 
-    cout << "Packed from " << in_size << " to " << out_idx.tellp() << endl;
+    if (!opt.quiet)
+        cout << "Index packed from " << in_size << " to " << out_idx.tellp() << endl;
 
-    // End, write the header
+    // Done, write the header at the begining of the file
     in_idx.close();
     out_idx.seekp(0);
-    out_idx.write(reinterpret_cast<char *>(header.data()), header.size() * sizeof(uint64_t));
+    out_idx.write(reinterpret_cast<char *>(header.data()), header_size);
     out_idx.close();
-    return 0;
+    return NO_ERR;
+}
+
+int unpack(const options &opt) {
+    cerr << "Unpack not yet implemented\n";
+    return INTERNAL_ERR;
+}
+
+int main(int argc, char **argv)
+{
+    options opt(parse(argc, argv));
+    if (!opt.error.empty())
+        return Usage(opt.error);
+
+    if (opt.unpack)
+        return unpack(opt);
+    return pack(opt);
 }

--- a/mrf_apps/packindex.cpp
+++ b/mrf_apps/packindex.cpp
@@ -1,0 +1,107 @@
+/*
+ * file: packindex.cpp
+ *
+ * Purpose:
+ *
+ * Packed Format:
+ *
+ * The MRF packed format consist of a header of size 32 * (1 + isize / 49152), followed
+ * by the 512 byte blocks of the original MRF index that do hold value
+ * The output index will be 1/1536 of the original size, plus the actual content blocks
+ * 
+ */
+
+#include <string>
+#include <vector>
+#include <fstream>
+#include <iostream>
+#include <cassert>
+// #include <cinttypes>
+
+using namespace std;
+
+// Compare a substring of src with cmp, return true if same
+// offset can be negative, in which case it is measured from the end of the src, python style
+static bool substr_equal(const string &src, const string &cmp, int off = 0, size_t len = 0) {
+    if (off < 0)
+        off += static_cast<int>(src.size());
+    if (off < 0 || off >= src.size())
+        return false; // usage Error
+    return cmp == (len ? src.substr(off, len) : src.substr(off));
+}
+
+inline bool check(const char *src, size_t len = 512) {
+    assert(len % 8 == 0);
+    len /= 8;
+    const uint64_t *p = reinterpret_cast<const uint64_t *>(src);
+    uint64_t accumulator = 0;
+    while (len--)
+        accumulator |= *p++;
+    return 0 == accumulator;
+}
+
+
+int main(int argc, char **argv)
+{
+    assert(argc > 2);
+    string in_idx_name(argv[1]);
+    string out_idx_name(argv[2]);
+    assert(substr_equal(in_idx_name, ".idx", -4));
+    assert(substr_equal(out_idx_name, ".ix", -3));
+
+    ifstream in_idx(in_idx_name, fstream::binary);
+    ofstream out_idx(out_idx_name, fstream::binary);
+
+    if (!in_idx.is_open() || !out_idx.is_open()) {
+        cerr << "Can't open " << (in_idx.is_open() ? out_idx_name: in_idx_name) << endl;
+        return 1;
+    }
+
+    in_idx.seekg(0, fstream::end);
+    auto in_size = in_idx.tellg();
+    in_idx.seekg(0);
+    assert(in_size % 16 == 0);
+
+    uint64_t header_size = 32 * (1 + in_size / 49152);
+    cout << "Header will be " << header_size << " bytes" << endl;
+
+    // Get space for the header and reserve space on disk,
+    // Header will be written at the end
+    vector<uint64_t> header(header_size / sizeof(uint64_t));
+    out_idx.seekp(header_size, fstream::beg);
+    
+    size_t out_block_count = 0;
+    size_t in_block_count = 1 + in_size / 512;
+    // Block buffer
+    char buffer[512];
+
+    // Check all full blocks, transferring them as needed
+    while (--in_block_count) {
+        in_idx.read(buffer, 512);
+        if (!check(buffer)) {
+            out_idx.write(buffer, 512);
+            out_block_count++;
+        }
+    }
+
+    // Last block can be partial
+    if (in_size % 512) {
+        auto extras = in_size % 512 / 8;
+        in_idx.read(reinterpret_cast<char *>(buffer), extras * 8);
+        for (auto i = extras ; i < 512 / 8 ; i++)
+            buffer[i] = 0;
+        if (!check(buffer)) {
+            out_idx.write(buffer, 512);
+            out_block_count++;
+        }
+    }
+
+    cout << "Packed from " << in_size << " to " << out_idx.tellp() << endl;
+
+    // End, write the header
+    in_idx.close();
+    out_idx.seekp(0);
+    out_idx.write(reinterpret_cast<char *>(header.data()), header.size() * sizeof(uint64_t));
+    out_idx.close();
+    return 0;
+}


### PR DESCRIPTION
Code to convert an index with holes to a dense index (canned).  This makes the MRF read-only, but it can reduce the complexities of handling large files with holes.
Note that a canned index is not compressed, it is only a format that explicitly removes blocks that are filled with zeros.  This means that the index can still be read very fast.