### PR TITLE
Gitc 6502: Add back start_level and stop_level functionality

### DIFF
--- a/mrf_apps/mrf_insert.cpp
+++ b/mrf_apps/mrf_insert.cpp
@@ -385,7 +385,6 @@ bool state::patch()
         // Convert level limits to source levels
         start_level--;
 
-        // Loop through each source level
         for (int sl = 0; sl < overview_count; sl++)
         {
             if (sl >= start_level && sl < stop_level)
@@ -393,13 +392,18 @@ bool state::patch()
                 pTarg->PatchOverview(BlockX, BlockY, Width, Height,
                                      sl, false, Resampling);
                 GDALFlushCache(hDataset);
+
+                if (verbose != 0)
+                {
+                    cerr << "Overview Level: " << sl << endl;
+                    cerr << "WidthOut = " << WidthOut << " HeightOut = " << HeightOut << endl;
+                }
             }
 
             // Update BlockX and BlockY for the next level (round down)
             int BlockXOut = BlockX / 2;
             int BlockYOut = BlockY / 2;
 
-            // Adjust Width and Height before division
             Width += (BlockX & 1);  // Increment width if BlockX was rounded down
             Height += (BlockY & 1); // Increment height if BlockY was rounded down
 

--- a/mrf_apps/mrf_insert.cpp
+++ b/mrf_apps/mrf_insert.cpp
@@ -396,7 +396,7 @@ bool state::patch()
                 if (verbose != 0)
                 {
                     cerr << "Overview Level: " << sl << endl;
-                    cerr << "WidthOut = " << WidthOut << " HeightOut = " << HeightOut << endl;
+                    cerr << "WidthOut = " << Width << " HeightOut = " << Height << endl;
                 }
             }
 


### PR DESCRIPTION
This change adds back the start_level and stop_level overview generation functionality to mrf_insert, which was a regression from an earlier PR. Functional testing on Opera data shows that this fixes a visual bug detected in overviews generated from that data. Unit test data in onearth will have to be reverted to their old versions as the overview appearance will now be the same as before.